### PR TITLE
console: fix build error

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -19,7 +19,6 @@ pub enum ForegroundColor {
     Magenta = 0x5,
     Brown = 0x6,
     LightGray = 0x7,
-    Bright = 0x8,
     DarkGray = 0x8,
     LightBlue = 0x9,
     LightGreen = 0xA,


### PR DESCRIPTION
now, enum ForegroundColor have two member using 0x08.
remove Bright = 0x08 to avoid this problem.