### PR TITLE
travis: add stable/beta/alpha matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: rust
 rust:
+  - stable
+  - beta
   - nightly
 
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,7 +1,6 @@
 use core::{default, fmt, ptr, slice};
 
 use void::CVoid;
-use systemtable;
 
 /// Type for EFI_HANDLE.
 #[derive(Copy, Clone, Debug)]

--- a/src/bootservices.rs
+++ b/src/bootservices.rs
@@ -2,10 +2,9 @@ use core::ptr;
 use core::mem;
 
 use void::{NotYetDef, CVoid};
-use base::{Event, Handle, Handles, MemoryType, Status, Time};
+use base::{Event, Handle, Handles, MemoryType, Status};
 use guid;
 use table;
-use systemtable;
 
 #[repr(C)]
 pub enum LocateSearchType {

--- a/src/console.rs
+++ b/src/console.rs
@@ -19,7 +19,6 @@ pub enum ForegroundColor {
     Magenta = 0x5,
     Brown = 0x6,
     LightGray = 0x7,
-    Bright = 0x8,
     DarkGray = 0x8,
     LightBlue = 0x9,
     LightGreen = 0xA,

--- a/src/runtimeservices.rs
+++ b/src/runtimeservices.rs
@@ -1,5 +1,4 @@
 use core::ptr;
-use core::fmt;
 
 use void::NotYetDef;
 use base::{Status, Time, TimeCapabilities};


### PR DESCRIPTION
This adds a full stable/beta/alpha matrix to travis. It cleans some unused-import warnings too.

It includes https://github.com/mischief/rust-uefi/pull/2 in order to fix the pre-existing build failure.