### PR TITLE
Add event/timer functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: rust
 rust:
+  - stable
+  - beta
   - nightly
-
+matrix:
+  allow_failures:
+    - rust: nightly
+script: cargo test

--- a/src/base.rs
+++ b/src/base.rs
@@ -65,7 +65,7 @@ impl<'a> ::core::iter::ExactSizeIterator for HandlesIterator<'a> {
 /// Type for EFI_EVENT.
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Event(*mut CVoid);
+pub struct Event(pub *mut CVoid);
 
 /// Type for EFI_STATUS
 #[cfg_attr(target_pointer_width = "32", repr(u32))]

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,7 +1,6 @@
 use core::{default, fmt, ptr, slice};
 
 use void::CVoid;
-use systemtable;
 
 /// Type for EFI_HANDLE.
 #[derive(Copy, Clone, Debug)]

--- a/src/bootservices.rs
+++ b/src/bootservices.rs
@@ -2,10 +2,9 @@ use core::ptr;
 use core::mem;
 
 use void::{NotYetDef, CVoid};
-use base::{Event, Handle, Handles, MemoryType, Status, Time};
+use base::{Event, Handle, Handles, MemoryType, Status};
 use guid;
 use table;
-use systemtable;
 
 #[repr(C)]
 pub enum LocateSearchType {

--- a/src/console.rs
+++ b/src/console.rs
@@ -19,7 +19,6 @@ pub enum ForegroundColor {
     Magenta = 0x5,
     Brown = 0x6,
     LightGray = 0x7,
-    Bright = 0x8,
     DarkGray = 0x8,
     LightBlue = 0x9,
     LightGreen = 0xA,

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,12 +1,16 @@
+use core::ptr;
+
 use void::*;
 use base::{Event, Status};
+use event::*;
+use task::TPL;
 use systemtable;
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct InputKey {
-    scan_code: u16,
-    unicode_char: u16,
+    pub scan_code: u16,
+    pub unicode_char: u16,
 }
 
 #[repr(u8)]
@@ -123,6 +127,7 @@ pub trait SimpleTextOutput {
 pub trait SimpleTextInput {
     fn read_key_async(&self) -> Result<InputKey, Status>;
     fn read_key(&self) -> Result<InputKey, Status>;
+    fn read_key_timeout(&self, timeout_millis: u64) -> Option<Result<InputKey, Status>>;
 }
 
 pub struct Console {
@@ -197,6 +202,32 @@ impl SimpleTextInput for Console {
                         _ => return Err(s),
                     }
                 },
+            }
+        }
+    }
+
+    fn read_key_timeout(&self, timeout_millis: u64) -> Option<Result<InputKey, Status>> {
+        let bs = self.system_table.boot_services();
+
+        match bs.create_event(EventType::Timer, TPL::Application, None, ptr::null()) {
+            Ok(timer_event) => {
+                let events : [Event; 2] = [self.input.wait_for_key, timer_event];
+
+                let set_result = bs.set_timer(timer_event, TimerDelay::Relative, timeout_millis);
+                if set_result != Status::Success {
+                    return Some(Err(set_result));
+                }
+
+                if let Ok(event_index) = bs.wait_for_event(&events) {
+                    if event_index == 0 {
+                        return Some(self.read_key_async());
+                    }
+                }
+
+                None
+            },
+            Err(status) => {
+                Some(Err(status))
             }
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,21 @@
+use void::CVoid;
+use base::Event;
+
+#[repr(u32)]
+pub enum EventType {
+    Timer = 0x80000000,
+    Runtime = 0x40000000,
+    NotifyWait = 0x00000100,
+    NotifySignal = 0x00000200,
+    SignalExitBootServices = 0x00000201,
+    SignalVirtualAddressChange = 0x60000202
+}
+
+#[repr(C)]
+pub enum TimerDelay {
+    Cancel = 0,
+    Periodic = 1,
+    Relative = 2
+}
+
+pub type EventNotify = extern "win64" fn(event: Event, context: *const CVoid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ mod systemtable;
 mod bootservices;
 mod runtimeservices;
 mod console;
+mod task;
+mod event;
 
 
 use void::{NotYetDef};
@@ -23,6 +25,10 @@ pub use bootservices::BootServices;
 pub use runtimeservices::{ResetType, RuntimeServices};
 
 pub use console::{Attribute, ForegroundColor, BackgroundColor, InputKey, SimpleTextOutput, SimpleTextInput, Console};
+
+pub use event::*;
+
+pub use task::*;
 
 pub trait Protocol {
     fn guid() -> &'static guid::Guid;

--- a/src/runtimeservices.rs
+++ b/src/runtimeservices.rs
@@ -1,5 +1,4 @@
 use core::ptr;
-use core::fmt;
 
 use void::NotYetDef;
 use base::{Status, Time, TimeCapabilities};

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,7 @@
+#[repr(usize)]
+pub enum TPL {
+    Application = 4,
+    Callback = 8,
+    Notify = 16,
+    HighLevel = 31
+}


### PR DESCRIPTION
Add the `create_event` and `set_timer` boot services calls, and add a function `read_key_timeout` to `Console` utilizing those calls.